### PR TITLE
Fixed misspelling of 'CUSTOM' in lock proxy docs

### DIFF
--- a/source/includes/67_lock_proxy_commands/_14-SETCUSTOMSETTINGS.md
+++ b/source/includes/67_lock_proxy_commands/_14-SETCUSTOMSETTINGS.md
@@ -5,7 +5,7 @@ This command results in the Protocol Notification [`CUSTOM_SETTINGS`][1] being s
 
 ### Signature
 
-`SET_CUSTUM_SETTINGS ()`
+`SET_CUSTOM_SETTINGS ()`
 
 
 | Parameter | Description |

--- a/source/includes/67_lock_proxy_commands/_8-REQUESTCUSTOMSETTINGS.md
+++ b/source/includes/67_lock_proxy_commands/_8-REQUESTCUSTOMSETTINGS.md
@@ -5,7 +5,7 @@ This command results in the Protocol Notification [`CUSTOM_SETTINGS`][1] being s
 
 ### Signature
 
-`REQUEST_CUSTUM_SETTINGS ()`
+`REQUEST_CUSTOM_SETTINGS ()`
 
 
 ### Parameters


### PR DESCRIPTION
Fixed a misspelling, assuming the lock proxy call really isn't 'REQUEST_CUSTUM_SETTINGS'...  :)